### PR TITLE
fix(ci): only trigger CI on push event at main branch

### DIFF
--- a/.github/workflows/CompileTimeDelta.yml
+++ b/.github/workflows/CompileTimeDelta.yml
@@ -4,10 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [closed]
-    branches:
-      - main
 
 jobs:
   linux-ubuntu:
@@ -16,7 +12,6 @@ jobs:
     env:
       CARGO_TERM_COLOR: always
 
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
     steps:
       - name: Checkout main repo
         uses: actions/checkout@v4


### PR DESCRIPTION
We should only trigger the CI on "push" event at main branch not at PR being closed & merged

When the PR is merged
- it seems the CI runs at the last commit made on the PR(as a push event + merge event action)
- and also on the merge commit, which is a "push" event

Hence, this causes double CI run and creates issue of incorrect synchronization with compile timing CI later

